### PR TITLE
Fix auto-inserts line comment inside block comments with =

### DIFF
--- a/languages/lua/config.toml
+++ b/languages/lua/config.toml
@@ -2,7 +2,7 @@ name = "Lua"
 grammar = "lua"
 path_suffixes = ["lua"]
 line_comments = ["-- ", "--- "]
-block_comment = ["--[[", "]]"]
+block_comment = ["--[", "]"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
Closes [#34226](https://github.com/zed-industries/zed/issues/34226)

Testing only `—[` as a prefix is sufficient to be considered a block comment, which excludes auto-insertion for line comments when matched.
