### PR TITLE
Bump tree-sitter-lua from v0.1.0 to v0.4.0

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -12,4 +12,4 @@ language = "Lua"
 
 [grammars.lua]
 repository = "https://github.com/tree-sitter-grammars/tree-sitter-lua"
-commit = "a24dab177e58c9c6832f96b9a73102a0cfbced4a"
+commit = "4569d1c361129e71a205b94a05e158bd71b1709f"


### PR DESCRIPTION
Bumps to latest tree-sitter (from v0.21.0 to v0.25.3) and a couple small syntax improvements like support for LuaJIT binary literals: 

| Before | After |
|-|-|
| <img width="241" height="71" alt="Screenshot 2025-11-05 at 10 42 24 AM" src="https://github.com/user-attachments/assets/ffc57812-1e48-427b-8cd1-43eec87e4986" /> | <img width="259" height="67" alt="Screenshot 2025-11-05 at 10 43 45 AM" src="https://github.com/user-attachments/assets/e6872013-903d-4a45-89b6-827837c1a3d1" /> |

Diff: https://github.com/tree-sitter-grammars/tree-sitter-lua/compare/a24dab177e58c9c6832f96b9a73102a0cfbced4a...4569d1c361129e71a205b94a05e158bd71b1709f