### PR TITLE
Bump version to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "zed_lua"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_lua"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "lua"
 name = "Lua"
 description = "Lua support."
-version = "0.1.5"
+version = "0.1.6"
 schema_version = 1
 authors = ["Max Brunsfeld <max@zed.dev>"]
 repository = "https://github.com/zed-extensions/lua"


### PR DESCRIPTION
Includes:

- https://github.com/zed-extensions/lua/pull/10
- https://github.com/zed-extensions/lua/pull/12